### PR TITLE
Add item tracking

### DIFF
--- a/src/main/java/gg/paceman/tracker/EventTracker.java
+++ b/src/main/java/gg/paceman/tracker/EventTracker.java
@@ -165,4 +165,8 @@ public class EventTracker {
         this.readProgress = 0;
         this.runStartTime = -1;
     }
+
+    public Path getWorldPath() {
+        return this.worldPath;
+    }
 }

--- a/src/main/java/gg/paceman/tracker/ItemTracker.java
+++ b/src/main/java/gg/paceman/tracker/ItemTracker.java
@@ -1,0 +1,101 @@
+package gg.paceman.tracker;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+import gg.paceman.tracker.util.ExceptionUtil;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+
+public class ItemTracker {
+    private static final Gson GSON = new Gson();
+    private Dictionary<String, Integer> estimatedCounts;
+    private Dictionary<String, Integer> usages;
+
+    public void tryUpdate(Path worldPath) {
+        try {
+            this.update(worldPath);
+        } catch (Exception e) {
+            PaceManTracker.logError("ItemTracker update failed: " + ExceptionUtil.toDetailedString(e));
+        }
+    }
+
+    private void update(Path worldPath) throws IOException, JsonSyntaxException {
+        // Clear tables (and trash old ones)
+        this.estimatedCounts = new Hashtable<>();
+        this.usages = new Hashtable<>();
+
+        Path recordFile = worldPath.resolve("speedrunigt").resolve("record.json");
+        if (!Files.exists(recordFile)) { // No record file shouldn't happen, but I guess if it does then give up /shrug
+            return;
+        }
+
+        JsonObject json = GSON.fromJson(new String(Files.readAllBytes(recordFile)), JsonObject.class);
+
+        if (!json.keySet().contains("stats")) {
+            return;
+        }
+
+        JsonObject stats = json.getAsJsonObject("stats");
+        Set<Map.Entry<String, JsonElement>> entries = stats.entrySet();
+        if (entries.isEmpty()) {
+            return;
+        }
+        stats = entries.stream().findAny().get().getValue().getAsJsonObject().getAsJsonObject("stats");
+
+        //
+        if (stats.has("minecraft:picked_up")) {
+            JsonObject pickedUp = stats.getAsJsonObject("minecraft:picked_up");
+            for (Map.Entry<String, JsonElement> entry : pickedUp.entrySet()) {
+                // Set count estimate for this item
+                this.estimatedCounts.put(entry.getKey(), entry.getValue().getAsInt());
+            }
+        }
+
+        if (stats.has("minecraft:dropped")) {
+            JsonObject dropped = stats.getAsJsonObject("minecraft:dropped");
+            for (Map.Entry<String, JsonElement> entry : dropped.entrySet()) {
+                // Subtract from count estimate for this item
+                Optional.ofNullable(this.estimatedCounts.get(entry.getKey()))
+                        .ifPresent(i -> this.estimatedCounts.put(entry.getKey(), i - entry.getValue().getAsInt()));
+            }
+        }
+
+        if (stats.has("minecraft:used")) {
+            JsonObject used = stats.getAsJsonObject("minecraft:used");
+            for (Map.Entry<String, JsonElement> entry : used.entrySet()) {
+                // Subtract from count estimate for this item
+                Optional.ofNullable(this.estimatedCounts.get(entry.getKey()))
+                        .ifPresent(i -> this.estimatedCounts.put(entry.getKey(), i - entry.getValue().getAsInt()));
+                // Set usages for this item
+                this.usages.put(entry.getKey(), entry.getValue().getAsInt());
+            }
+        }
+    }
+
+    public int getEstimatedCount(String item) {
+        return Optional.ofNullable(this.estimatedCounts.get(item)).orElse(0);
+    }
+
+    public int getUsages(String item) {
+        return Optional.ofNullable(this.usages.get(item)).orElse(0);
+    }
+
+    public Optional<JsonObject> constructItemData(Set<String> itemsToGetEstimate, Set<String> itemsToGetUsage) {
+        JsonObject estimatedCounts = new JsonObject();
+        itemsToGetEstimate.stream().filter(s -> this.getEstimatedCount(s) > 0).forEach(s -> estimatedCounts.addProperty(s, this.getEstimatedCount(s)));
+        JsonObject usages = new JsonObject();
+        itemsToGetUsage.stream().filter(s -> this.getUsages(s) > 0).forEach(s -> usages.addProperty(s, this.getUsages(s)));
+        JsonObject itemData = new JsonObject();
+        if (estimatedCounts.size() == 0 && usages.size() == 0) {
+            return Optional.empty();
+        }
+        itemData.add("estimatedCounts", estimatedCounts);
+        itemData.add("usages", usages);
+        return Optional.of(itemData);
+    }
+}

--- a/src/main/java/gg/paceman/tracker/PaceManTracker.java
+++ b/src/main/java/gg/paceman/tracker/PaceManTracker.java
@@ -31,8 +31,8 @@ public class PaceManTracker {
     // Unimportant events are not considered when determining if an event is recent enough to send the run to PaceMan
     private static final List<String> UNIMPORTANT_EVENTS = Arrays.asList("common.leave_world", "common.rejoin_world");
 
-    private static final Set<String> IMPORTANT_ITEM_COUNTS = new HashSet<>(Arrays.asList("minecraft:ender_pearl","minecraft:obsidian","minecraft:blaze_rod"));
-    private static final Set<String> IMPORTANT_ITEM_USAGES = new HashSet<>(Arrays.asList("minecraft:ender_pearl","minecraft:obsidian"));
+    private static final Set<String> IMPORTANT_ITEM_COUNTS = new HashSet<>(Arrays.asList("minecraft:ender_pearl", "minecraft:obsidian", "minecraft:blaze_rod"));
+    private static final Set<String> IMPORTANT_ITEM_USAGES = new HashSet<>(Arrays.asList("minecraft:ender_pearl", "minecraft:obsidian"));
 
     private static final Pattern RANDOM_WORLD_PATTERN = Pattern.compile("^Random Speedrun #\\d+$");
 

--- a/src/main/java/gg/paceman/tracker/PaceManTracker.java
+++ b/src/main/java/gg/paceman/tracker/PaceManTracker.java
@@ -31,6 +31,9 @@ public class PaceManTracker {
     // Unimportant events are not considered when determining if an event is recent enough to send the run to PaceMan
     private static final List<String> UNIMPORTANT_EVENTS = Arrays.asList("common.leave_world", "common.rejoin_world");
 
+    private static final Set<String> IMPORTANT_ITEM_COUNTS = new HashSet<>(Arrays.asList("minecraft:ender_pearl","minecraft:obsidian","minecraft:blaze_rod"));
+    private static final Set<String> IMPORTANT_ITEM_USAGES = new HashSet<>(Arrays.asList("minecraft:ender_pearl","minecraft:obsidian"));
+
     private static final Pattern RANDOM_WORLD_PATTERN = Pattern.compile("^Random Speedrun #\\d+$");
 
     private static final long RUN_TOO_LONG_MILLIS = 3_600_000; // 1 hour
@@ -44,6 +47,7 @@ public class PaceManTracker {
     public static Consumer<String> warningConsumer = System.out::println;
 
     private final EventTracker eventTracker = new EventTracker(Paths.get(System.getProperty("user.home")).resolve("speedrunigt").resolve("latest_world.json").toAbsolutePath());
+    private final ItemTracker itemTracker = new ItemTracker();
     private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
     private boolean asPlugin;
 
@@ -151,6 +155,8 @@ public class PaceManTracker {
             }
         }
 
+        this.itemTracker.tryUpdate(this.eventTracker.getWorldPath());
+
         List<String> latestNewLines = this.eventTracker.getLatestNewLines();
         if (!latestNewLines.isEmpty()) {
             PaceManTracker.logDebug("New Lines: " + latestNewLines);
@@ -245,7 +251,8 @@ public class PaceManTracker {
                         PaceManTrackerOptions.getInstance().accessKey,
                         this.headerToSend,
                         this.eventsToSend,
-                        this.getTimeSinceRunStart()
+                        this.getTimeSinceRunStart(),
+                        this.itemTracker.constructItemData(IMPORTANT_ITEM_COUNTS, IMPORTANT_ITEM_USAGES)
                 )
         )) {
             if (++tries < 5) {

--- a/src/main/java/gg/paceman/tracker/util/PacemanGGUtil.java
+++ b/src/main/java/gg/paceman/tracker/util/PacemanGGUtil.java
@@ -12,6 +12,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class PacemanGGUtil {
@@ -30,7 +31,7 @@ public class PacemanGGUtil {
         return PacemanGGUtil.sendToPacemanGG(eventModelInput.toString());
     }
 
-    public static PaceManResponse sendEventsToPacemanGG(String accessKey, String latestWorldContents, List<String> events, long timeSinceRunStart) {
+    public static PaceManResponse sendEventsToPacemanGG(String accessKey, String latestWorldContents, List<String> events, long timeSinceRunStart, Optional<JsonObject> itemDataOpt) {
         JsonObject eventModelInput = new JsonObject();
         eventModelInput.addProperty("accessKey", accessKey);
 
@@ -58,6 +59,11 @@ public class PacemanGGUtil {
         eventModelInput.add("eventList", eventList);
 
         eventModelInput.addProperty("timeSinceRunStart", timeSinceRunStart);
+        itemDataOpt.ifPresent(itemData -> {
+            if (!itemData.keySet().isEmpty()) {
+                eventModelInput.add("itemData", itemData);
+            }
+        });
 
         String toSend = eventModelInput.toString();
         PaceManTracker.logDebug("Sending exactly: " + toSend.replace(accessKey, "KEY_HIDDEN"));


### PR DESCRIPTION
Adds support for the internally discussed "item data"; the tracker will support item data being sent to the endpoint specified by these interfaces:
```ts
export interface EventModelInput {
  ...
  itemData?: ItemData;
}

export interface ItemData {
  estimatedCounts: Dictionary/Map/Table<String, number>; // (whatever's in js)
  usages: Dictionary/Map/Table<String, number>;
}
```

In the code, an `ItemTracker` is implemented which holds estimates of item counts and item usages, and can construct a `JsonObject` based on requested item types, and will match the spec of `ItemData`.
The `ItemTracker` is updated whenever new events are detected, and if any relevant items have a usage or estimated count, the item data will be sent along with the new event.