### PR TITLE
Add resetting stats

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ configurations {
 
 dependencies {
     // Choose Julti version: https://jitpack.io/#DuncanRuns/Julti/
-    implementation 'com.github.DuncanRuns:Julti:8044a00c24'
+    implementation 'com.github.DuncanRuns:Julti:568fbeb03a'
 
     provided 'com.jetbrains.intellij.java:java-gui-forms-rt:203.7148.30'
     provided 'com.google.code.gson:gson:2.10'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 # Plugin properties
 maven_group=gg.paceman.tracker
-version=0.5.0
+version=0.6.0
 archives_base_name=paceman-tracker

--- a/src/main/java/gg/paceman/tracker/PaceManTracker.java
+++ b/src/main/java/gg/paceman/tracker/PaceManTracker.java
@@ -216,12 +216,10 @@ public class PaceManTracker {
         JsonObject eventModelInput = new JsonObject();
         eventModelInput.addProperty("accessKey", options.accessKey);
 
-        String worldId = "";
-
         if (this.headerToSend != null) {
             JsonObject latestWorldJson = new Gson().fromJson(this.headerToSend, JsonObject.class);
             JsonArray mods = latestWorldJson.getAsJsonArray("mods");
-            worldId = PaceManTracker.sha256Hash(latestWorldJson.get("world_path").getAsString() + this.worldUniquifier);
+            String worldId = PaceManTracker.sha256Hash(latestWorldJson.get("world_path").getAsString() + this.worldUniquifier);
             String gameVersion = latestWorldJson.get("version").getAsString();
             String srIGTVersion = latestWorldJson.has("mod_version") ? (latestWorldJson.get("mod_version").getAsString().split("\\+")[0]) : "14.0";
             String category = latestWorldJson.get("category").getAsString();
@@ -255,10 +253,10 @@ public class PaceManTracker {
 
         PaceManResponse response = PaceManTracker.sendToPacemanGG(toSend);
 
-        if(response == PaceManResponse.SUCCESS && !this.runOnPaceMan && !worldId.isEmpty()){
+        if(response == PaceManResponse.SUCCESS && !this.runOnPaceMan && this.headerToSend != null){
             PaceManTracker.logDebug("Submitting reset stats");
             try {
-                this.stateTracker.dumpStats(worldId);
+                this.stateTracker.dumpStats(eventModelInput);
             } catch (Throwable t) {
                 String detailedString = ExceptionUtil.toDetailedString(t);
                 PaceManTracker.logWarning("Error while submitting stats: " + detailedString);

--- a/src/main/java/gg/paceman/tracker/PaceManTrackerOptions.java
+++ b/src/main/java/gg/paceman/tracker/PaceManTrackerOptions.java
@@ -21,6 +21,7 @@ public class PaceManTrackerOptions {
     public String accessKey = "";
     public boolean enabledForPlugin = false;
     public boolean allowAnyWorldName = false;
+    public boolean resetStatsEnabled = true;
 
     /**
      * Load and return the options file

--- a/src/main/java/gg/paceman/tracker/StateTracker.java
+++ b/src/main/java/gg/paceman/tracker/StateTracker.java
@@ -192,6 +192,10 @@ public class StateTracker {
     }
 
     public void dumpStats(JsonObject data){
+        if(!PaceManTrackerOptions.getInstance().resetStatsEnabled){
+            PaceManTracker.logDebug("Not submitting stats since user opted out");
+            return;
+        }
         JsonObject gameData = data.getAsJsonObject("gameData");
         String mods = gameData.getAsJsonArray("modList").toString();
         if(!mods.contains("seedqueue") || !mods.contains("state-output")){

--- a/src/main/java/gg/paceman/tracker/StateTracker.java
+++ b/src/main/java/gg/paceman/tracker/StateTracker.java
@@ -1,0 +1,224 @@
+package gg.paceman.tracker;
+
+import com.google.gson.JsonObject;
+import gg.paceman.tracker.util.ExceptionUtil;
+import gg.paceman.tracker.util.SleepUtil;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class StateTracker {
+
+    private enum State {
+        UNKNOWN, IDLE, WALL, LOADING, PLAYING
+    }
+
+    private final int breakThreshold = 5000;
+
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    private Path lastWorldPath;
+    private Path statePath;
+    private boolean hasStateFile = false;
+    private long stateLastMod = -1;
+    private State currentState = State.UNKNOWN;
+
+    private Path resetsPath;
+    private boolean hasResetsFile = false;
+    private long resetsLastMod = -1;
+    private int resets = 0;
+    private int lastResets = 0;
+    private long lastWallReset = 0;
+
+    private boolean isPracticing = false;
+
+    private int seedsPlayed = 0;
+    private long playingStart = 0;
+    private long playTime = 0;
+    private long wallTime = 0;
+
+    private static final String SUBMIT_STATS_ENDPOINT = "https://paceman.gg/stats/api/submitStats";
+
+    public void start(){
+        this.executor.scheduleAtFixedRate(this::tickInstPath, 0, 1, TimeUnit.SECONDS);
+        this.executor.scheduleAtFixedRate(this::tryTick, 0, 50, TimeUnit.MILLISECONDS);
+    }
+
+    public void tickInstPath(){
+        Thread.currentThread().setName("state-tick-inst");
+        Path worldPath = PaceManTracker.getInstance().getWorldPath();
+        if(worldPath == null || worldPath.equals(this.lastWorldPath)){
+            return;
+        }
+
+        this.lastWorldPath = worldPath;
+
+        boolean allowAnyWorldName = PaceManTrackerOptions.getInstance().allowAnyWorldName;
+        boolean isRandomSpeedrunWorld = PaceManTracker.RANDOM_WORLD_PATTERN.matcher(worldPath.getFileName().toString()).matches();
+        this.isPracticing = !allowAnyWorldName && !isRandomSpeedrunWorld;
+
+        // Random Speedrun #X -> saves -> .minecraft
+        Path instFolder = worldPath.getParent().getParent();
+
+        this.statePath = instFolder.resolve("wpstateout.txt");
+        this.resetsPath = instFolder.resolve("config/mcsr/atum/rsg-attempts.txt");
+        this.hasStateFile = Files.exists(this.statePath);
+        this.hasResetsFile = Files.exists(this.resetsPath);
+    }
+
+    public void tryTick(){
+        try {
+            Thread.currentThread().setName("state-tick");
+            this.tick();
+            this.tickResets();
+        } catch (Throwable t) {
+            String detailedString = ExceptionUtil.toDetailedString(t);
+            PaceManTracker.logWarning("Error while checking state: " + detailedString);
+            PaceManTracker.logWarning("The above error only affects the NPH stats tracking, and can be ignored if it happens rarely.");
+        }
+    }
+
+    public void tick() throws IOException {
+        if(!this.hasStateFile){
+            return;
+        }
+        long newLM = Files.getLastModifiedTime(this.statePath).toMillis();
+        if (newLM == this.stateLastMod) {
+            return;
+        }
+        this.stateLastMod = newLM;
+
+        State oldState = this.currentState;
+        State newState = State.UNKNOWN;
+        String state = "";
+        for(int i = 0; i < 5; i++) {
+            state = new String(Files.readAllBytes(this.statePath), StandardCharsets.UTF_8);
+            switch (state.split(",")[0]) {
+                case "wall":
+                case "previewing":
+                    newState = State.WALL;
+                    break;
+                case "inworld":
+                    newState = State.PLAYING;
+                    break;
+                case "generating":
+                case "waiting":
+                    newState = State.LOADING;
+                    break;
+                case "title":
+                    newState = State.IDLE;
+                    break;
+                default:
+                    SleepUtil.sleep(5);
+                    continue;
+            }
+            break;
+        }
+        if(newState == State.UNKNOWN){
+            PaceManTracker.logWarning("State cannot be determined after 3 attempts: " + state);
+            return;
+        }
+
+        // joined instance
+        if(oldState != State.PLAYING && newState == State.PLAYING){
+            this.playingStart = newLM;
+            if(oldState != State.UNKNOWN){
+                // don't increment seeds played counter when tracker is restarted while in a world
+                this.seedsPlayed++;
+            }
+        }
+
+        // left instance
+        if(oldState == State.PLAYING && newState != State.PLAYING){
+            if(!this.isPracticing){
+                // commit playtime
+                long playDiff = newLM - this.playingStart;
+                this.playTime += playDiff;
+            }
+            this.isPracticing = false;
+        }
+
+        this.currentState = newState;
+    }
+
+    public void tickResets() throws IOException {
+        if(!this.hasResetsFile){
+            return;
+        }
+        long newLM = Files.getLastModifiedTime(this.resetsPath).toMillis();
+        if (newLM == this.resetsLastMod) {
+            return;
+        }
+        this.resetsLastMod = newLM;
+
+        if(this.currentState != State.WALL){
+            return;
+        }
+
+        int resets = 0;
+        for(int i = 0; i < 5; i++){
+            String contents = new String(Files.readAllBytes(this.resetsPath), StandardCharsets.UTF_8);
+            if(contents.isEmpty()){
+                SleepUtil.sleep(5);
+                continue;
+            }
+            resets = Integer.parseInt(contents);
+            break;
+        }
+
+        // first wall reset
+        if(this.lastWallReset == 0){
+            this.lastWallReset = newLM;
+            return;
+        }
+
+        long wallDiff = newLM - this.lastWallReset;
+        this.resets = resets;
+        this.lastWallReset = newLM;
+        if(wallDiff < this.breakThreshold){
+            this.wallTime += wallDiff;
+        }
+
+    }
+
+    public void dumpStats(){
+        int newResets = this.resets - this.lastResets;
+        JsonObject input = new JsonObject();
+        input.addProperty("accessKey", PaceManTrackerOptions.getInstance().accessKey);
+        input.addProperty("wallTime", this.wallTime);
+        input.addProperty("playTime", this.playTime);
+        input.addProperty("seedsPlayed", this.seedsPlayed);
+        input.addProperty("resets", newResets);
+        input.addProperty("totalResets", this.resets);
+
+        this.lastResets = this.resets;
+        this.playTime = 0;
+        this.wallTime = 0;
+        this.seedsPlayed = 0;
+
+        try {
+            PaceManTracker.PostResponse out = PaceManTracker.sendData(SUBMIT_STATS_ENDPOINT, input.toString());
+            int res = out.getCode();
+            PaceManTracker.logDebug("Stats Response " + res + ": " + out.getMessage());
+        } catch (Throwable t) {
+            String detailedString = ExceptionUtil.toDetailedString(t);
+            PaceManTracker.logError("Stats submission encountered an error: " + detailedString);
+        }
+    }
+
+    public void stop(){
+        Thread.currentThread().setName("state-stopping");
+        try {
+            // Wait for and shutdown executor
+            this.executor.shutdownNow();
+            this.executor.awaitTermination(10, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/main/java/gg/paceman/tracker/StateTracker.java
+++ b/src/main/java/gg/paceman/tracker/StateTracker.java
@@ -185,10 +185,11 @@ public class StateTracker {
 
     }
 
-    public void dumpStats(){
+    public void dumpStats(String worldId){
         int newResets = this.resets - this.lastResets;
         JsonObject input = new JsonObject();
         input.addProperty("accessKey", PaceManTrackerOptions.getInstance().accessKey);
+        input.addProperty("worldId", worldId);
         input.addProperty("wallTime", this.wallTime);
         input.addProperty("playTime", this.playTime);
         input.addProperty("seedsPlayed", this.seedsPlayed);

--- a/src/main/java/gg/paceman/tracker/StateTracker.java
+++ b/src/main/java/gg/paceman/tracker/StateTracker.java
@@ -200,6 +200,10 @@ public class StateTracker {
         }
 
         int newResets = this.resets - this.lastResets;
+
+        // add the overworld time spent in this run to playTime
+        this.playTime += System.currentTimeMillis() - this.playingStart;
+
         JsonObject input = new JsonObject();
         input.addProperty("gameData", gameData.toString());
         input.addProperty("accessKey", data.get("accessKey").getAsString());

--- a/src/main/java/gg/paceman/tracker/StateTracker.java
+++ b/src/main/java/gg/paceman/tracker/StateTracker.java
@@ -35,6 +35,7 @@ public class StateTracker {
     private long lastWallReset = 0;
 
     private boolean isPracticing = false;
+    private boolean isNether = false;
 
     private int seedsPlayed = 0;
     private long playingStart = 0;
@@ -134,12 +135,13 @@ public class StateTracker {
 
         // left instance
         if(oldState == State.PLAYING && newState != State.PLAYING){
-            if(!this.isPracticing){
+            if(!this.isPracticing && !this.isNether){
                 // commit playtime
                 long playDiff = newLM - this.playingStart;
                 this.playTime += playDiff;
             }
             this.isPracticing = false;
+            this.isNether = false;
         }
 
         this.currentState = newState;
@@ -200,6 +202,7 @@ public class StateTracker {
         this.playTime = 0;
         this.wallTime = 0;
         this.seedsPlayed = 0;
+        this.isNether = true;
 
         try {
             PaceManTracker.PostResponse out = PaceManTracker.sendData(SUBMIT_STATS_ENDPOINT, input.toString());

--- a/src/main/java/gg/paceman/tracker/gui/PaceManTrackerGUI.java
+++ b/src/main/java/gg/paceman/tracker/gui/PaceManTrackerGUI.java
@@ -23,6 +23,7 @@ public class PaceManTrackerGUI extends JFrame {
     private JPanel mainPanel;
     private JButton saveButton;
     private JButton testButton;
+    private JCheckBox resetStatsEnabled;
     private boolean closed = false;
     private final boolean asPlugin;
 
@@ -48,6 +49,10 @@ public class PaceManTrackerGUI extends JFrame {
             if (asPlugin) {
                 this.accessKeyField.setEnabled(this.checkBoxEnabled());
             }
+        });
+        this.resetStatsEnabled.setSelected(options.resetStatsEnabled);
+        this.resetStatsEnabled.addActionListener(e -> {
+            this.saveButton.setEnabled(this.hasChanges());
         });
         this.accessKeyField.setText(options.accessKey);
         this.accessKeyField.addKeyListener(new KeyAdapter() {
@@ -128,12 +133,13 @@ public class PaceManTrackerGUI extends JFrame {
 
     private boolean hasChanges() {
         PaceManTrackerOptions options = PaceManTrackerOptions.getInstance();
-        return (this.asPlugin && this.checkBoxEnabled() != options.enabledForPlugin) || (!Objects.equals(this.getKeyBoxText(), options.accessKey));
+        return (this.asPlugin && this.checkBoxEnabled() != options.enabledForPlugin) || (this.resetStatsEnabled() != options.resetStatsEnabled) || (!Objects.equals(this.getKeyBoxText(), options.accessKey));
     }
 
     private void save() {
         PaceManTrackerOptions options = PaceManTrackerOptions.getInstance();
         options.enabledForPlugin = this.checkBoxEnabled();
+        options.resetStatsEnabled = this.resetStatsEnabled();
         options.accessKey = this.getKeyBoxText().trim();
         try {
             options.save();
@@ -151,6 +157,10 @@ public class PaceManTrackerGUI extends JFrame {
 
     private boolean checkBoxEnabled() {
         return this.enabledCheckBox.isSelected();
+    }
+
+    private boolean resetStatsEnabled() {
+        return this.resetStatsEnabled.isSelected();
     }
 
     private String getKeyBoxText() {
@@ -185,16 +195,19 @@ public class PaceManTrackerGUI extends JFrame {
      */
     private void $$$setupUI$$$() {
         mainPanel = new JPanel();
-        mainPanel.setLayout(new GridLayoutManager(5, 2, new Insets(5, 5, 5, 5), -1, -1));
+        mainPanel.setLayout(new GridLayoutManager(6, 2, new Insets(5, 5, 5, 5), -1, -1));
         final JLabel label1 = new JLabel();
         label1.setText("PaceMan Tracker");
         mainPanel.add(label1, new GridConstraints(0, 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         enabledCheckBox = new JCheckBox();
         enabledCheckBox.setText("Enabled");
         mainPanel.add(enabledCheckBox, new GridConstraints(1, 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        resetStatsEnabled = new JCheckBox();
+        resetStatsEnabled.setText("Include resetting stats");
+        mainPanel.add(resetStatsEnabled, new GridConstraints(2, 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final JPanel panel1 = new JPanel();
         panel1.setLayout(new GridLayoutManager(1, 2, new Insets(0, 0, 0, 0), -1, -1));
-        mainPanel.add(panel1, new GridConstraints(2, 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
+        mainPanel.add(panel1, new GridConstraints(3, 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         accessKeyField = new JPasswordField();
         accessKeyField.setText("");
         panel1.add(accessKeyField, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_WANT_GROW, GridConstraints.SIZEPOLICY_FIXED, null, new Dimension(150, -1), null, 0, false));
@@ -202,13 +215,13 @@ public class PaceManTrackerGUI extends JFrame {
         label2.setText("Access Key:");
         panel1.add(label2, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final Spacer spacer1 = new Spacer();
-        mainPanel.add(spacer1, new GridConstraints(4, 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
+        mainPanel.add(spacer1, new GridConstraints(5, 0, 1, 2, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
         saveButton = new JButton();
         saveButton.setText("Save");
-        mainPanel.add(saveButton, new GridConstraints(3, 0, 1, 1, GridConstraints.ANCHOR_EAST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        mainPanel.add(saveButton, new GridConstraints(4, 0, 1, 1, GridConstraints.ANCHOR_EAST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         testButton = new JButton();
         testButton.setText("Test");
-        mainPanel.add(testButton, new GridConstraints(3, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
+        mainPanel.add(testButton, new GridConstraints(4, 1, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
     }
 
     /**

--- a/src/main/java/gg/paceman/tracker/gui/PacemanTrackerGUI.form
+++ b/src/main/java/gg/paceman/tracker/gui/PacemanTrackerGUI.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="gg.paceman.tracker.gui.PaceManTrackerGUI">
-  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="5" left="5" bottom="5" right="5"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -24,10 +24,18 @@
           <text value="Enabled"/>
         </properties>
       </component>
+      <component id="24f90" class="javax.swing.JCheckBox" binding="resetStatsEnabled">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Include resetting stats"/>
+        </properties>
+      </component>
       <grid id="f89eb" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -54,12 +62,12 @@
       </grid>
       <vspacer id="3efbb">
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="1554e" class="javax.swing.JButton" binding="saveButton">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Save"/>
@@ -67,7 +75,7 @@
       </component>
       <component id="2f9e6" class="javax.swing.JButton" binding="testButton" default-binding="true">
         <constraints>
-          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Test"/>


### PR DESCRIPTION
Adds support for tracking stats such as nethers per enter, seeds played, and resets per enter. This replaces the previous implementation which required OBS browser sources.
This requires the (currently unreleased) SeedQueue mod, as well as state-output. If either of these mods are missing, normal tracking will continue to work as intended, but resetting stats will not be tracked.

![image](https://github.com/user-attachments/assets/759ed8a5-855d-41b4-b996-b43b9deb1da9)
Submission of reset stats can be toggled by the user.

