### PR TITLE
Reset stats more often, ignore paused time in NPH, track time spent in nethers

### DIFF
--- a/src/main/java/gg/paceman/tracker/PaceManTracker.java
+++ b/src/main/java/gg/paceman/tracker/PaceManTracker.java
@@ -308,7 +308,7 @@ public class PaceManTracker {
         return PaceManTracker.sendToPacemanGG(eventModelInput.toString());
     }
 
-    private boolean shouldRun() {
+    public boolean shouldRun() {
         PaceManTrackerOptions options = PaceManTrackerOptions.getInstance();
         if (options.accessKey.isEmpty()) {
             return false;

--- a/src/main/java/gg/paceman/tracker/StateTracker.java
+++ b/src/main/java/gg/paceman/tracker/StateTracker.java
@@ -39,6 +39,7 @@ public class StateTracker {
 
     private boolean isPracticing = false;
     private boolean isNether = false;
+    private boolean isEnabled = false;
 
     private int seedsPlayed = 0;
     private long playingStart = 0;
@@ -50,6 +51,7 @@ public class StateTracker {
     private long netherTime = 0;
 
     public void start() {
+        this.executor.scheduleAtFixedRate(this::tickResetCheck, 0, 3, TimeUnit.SECONDS);
         this.executor.scheduleAtFixedRate(this::tickInstPath, 0, 1, TimeUnit.SECONDS);
         this.executor.scheduleAtFixedRate(this::tryTick, 0, 25, TimeUnit.MILLISECONDS);
     }
@@ -68,6 +70,21 @@ public class StateTracker {
         this.netherTime = 0;
         this.stateLastMod = -1;
         this.resetsLastMod = -1;
+    }
+
+    public void tickResetCheck() {
+        Thread.currentThread().setName("state-tick-reset");
+        PaceManTrackerOptions options = PaceManTrackerOptions.getInstance();
+
+        boolean wasEnabled = this.isEnabled;
+        this.isEnabled = options.resetStatsEnabled && options.enabledForPlugin;
+
+        if (this.isEnabled && !wasEnabled) {
+            PaceManTracker.logDebug("Reset stats enabled");
+            this.reset();
+        } else if (!this.isEnabled && wasEnabled) {
+            PaceManTracker.logDebug("Reset stats disabled");
+        }
     }
 
     public void tickInstPath() {

--- a/src/main/java/gg/paceman/tracker/StateTracker.java
+++ b/src/main/java/gg/paceman/tracker/StateTracker.java
@@ -299,6 +299,7 @@ public class StateTracker {
         this.wallTime = 0;
         this.seedsPlayed = 0;
         this.isNether = true;
+        this.netherTime = 0;
         this.netherStart = System.currentTimeMillis();
 
         try {

--- a/src/main/java/gg/paceman/tracker/StateTracker.java
+++ b/src/main/java/gg/paceman/tracker/StateTracker.java
@@ -77,7 +77,7 @@ public class StateTracker {
         PaceManTrackerOptions options = PaceManTrackerOptions.getInstance();
 
         boolean wasEnabled = this.isEnabled;
-        this.isEnabled = options.resetStatsEnabled && options.enabledForPlugin;
+        this.isEnabled = options.resetStatsEnabled && PaceManTracker.getInstance().shouldRun();
 
         if (this.isEnabled && !wasEnabled) {
             PaceManTracker.logDebug("Reset stats enabled");

--- a/src/main/java/gg/paceman/tracker/StateTracker.java
+++ b/src/main/java/gg/paceman/tracker/StateTracker.java
@@ -19,6 +19,8 @@ public class StateTracker {
     private final int breakThreshold = 5000;
     // cap each overworld segment to at most 10 minutes in case of afk
     private final int maxPlayTime = 1000 * 60 * 10;
+    // reset stats after no state changes for 1 hour
+    private final int maxAFKTime = 1000 * 60 * 60;
 
     private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
     private Path lastWorldPath;
@@ -112,6 +114,11 @@ public class StateTracker {
         long newLM = Files.getLastModifiedTime(this.statePath).toMillis();
         if (newLM == this.stateLastMod) {
             return;
+        }
+        long diff = newLM - this.stateLastMod;
+        if(diff > this.maxAFKTime){
+            PaceManTracker.logDebug("AFK for " + diff + "ms, resetting stats");
+            this.reset();
         }
         this.stateLastMod = newLM;
 

--- a/src/main/java/gg/paceman/tracker/StateTracker.java
+++ b/src/main/java/gg/paceman/tracker/StateTracker.java
@@ -98,7 +98,13 @@ public class StateTracker {
 
         boolean allowAnyWorldName = PaceManTrackerOptions.getInstance().allowAnyWorldName;
         boolean isRandomSpeedrunWorld = PaceManTracker.RANDOM_WORLD_PATTERN.matcher(worldPath.getFileName().toString()).matches();
+
+        boolean wasPracticing = this.isPracticing;
         this.isPracticing = !allowAnyWorldName && !isRandomSpeedrunWorld;
+        if(wasPracticing && !this.isPracticing){
+            PaceManTracker.logDebug("Stopped practicing, resetting stats");
+            this.reset();
+        }
 
         // Random Speedrun #X -> saves -> .minecraft
         Path instFolder = worldPath.getParent().getParent();

--- a/src/main/java/gg/paceman/tracker/StateTracker.java
+++ b/src/main/java/gg/paceman/tracker/StateTracker.java
@@ -22,6 +22,7 @@ public class StateTracker {
 
     private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
     private Path lastWorldPath;
+    private Path instPath;
     private Path statePath;
     private boolean hasStateFile = false;
     private long stateLastMod = -1;
@@ -49,6 +50,18 @@ public class StateTracker {
         this.executor.scheduleAtFixedRate(this::tryTick, 0, 50, TimeUnit.MILLISECONDS);
     }
 
+    public void reset() {
+        this.resets = 0;
+        this.lastResets = 0;
+        this.lastWallReset = 0;
+        this.seedsPlayed = 0;
+        this.playingStart = 0;
+        this.playTime = 0;
+        this.wallTime = 0;
+        this.pauseStart = 0;
+        this.pauseTime = 0;
+    }
+
     public void tickInstPath() {
         Thread.currentThread().setName("state-tick-inst");
         Path worldPath = PaceManTracker.getInstance().getWorldPath();
@@ -64,6 +77,11 @@ public class StateTracker {
 
         // Random Speedrun #X -> saves -> .minecraft
         Path instFolder = worldPath.getParent().getParent();
+        if(!instFolder.equals(this.instPath)){
+            this.instPath = instFolder;
+            PaceManTracker.logDebug("New instance folder: " + instFolder);
+            this.reset();
+        }
 
         this.statePath = instFolder.resolve("wpstateout.txt");
         this.resetsPath = instFolder.resolve("config/mcsr/atum/rsg-attempts.txt");

--- a/src/main/java/gg/paceman/tracker/StateTracker.java
+++ b/src/main/java/gg/paceman/tracker/StateTracker.java
@@ -66,6 +66,8 @@ public class StateTracker {
         this.pauseTime = 0;
         this.netherStart = 0;
         this.netherTime = 0;
+        this.stateLastMod = -1;
+        this.resetsLastMod = -1;
     }
 
     public void tickInstPath() {

--- a/src/main/java/gg/paceman/tracker/StateTracker.java
+++ b/src/main/java/gg/paceman/tracker/StateTracker.java
@@ -51,7 +51,7 @@ public class StateTracker {
 
     public void start() {
         this.executor.scheduleAtFixedRate(this::tickInstPath, 0, 1, TimeUnit.SECONDS);
-        this.executor.scheduleAtFixedRate(this::tryTick, 0, 50, TimeUnit.MILLISECONDS);
+        this.executor.scheduleAtFixedRate(this::tryTick, 0, 25, TimeUnit.MILLISECONDS);
     }
 
     public void reset() {

--- a/src/main/java/gg/paceman/tracker/StateTracker.java
+++ b/src/main/java/gg/paceman/tracker/StateTracker.java
@@ -259,9 +259,11 @@ public class StateTracker {
         long diff = Math.min(this.maxPlayTime, System.currentTimeMillis() - this.playingStart);
         this.playTime += diff;
 
+        String accessKey = data.get("accessKey").getAsString();
+
         JsonObject input = new JsonObject();
         input.addProperty("gameData", gameData.toString());
-        input.addProperty("accessKey", data.get("accessKey").getAsString());
+        input.addProperty("accessKey", accessKey);
         input.addProperty("wallTime", this.wallTime);
         input.addProperty("playTime", this.playTime);
         input.addProperty("netherTime", this.netherTime);
@@ -277,6 +279,8 @@ public class StateTracker {
         this.netherStart = System.currentTimeMillis();
 
         try {
+            String toSend = input.toString();
+            PaceManTracker.logDebug("Sending reset stats: " + toSend.replace(accessKey, "KEY_HIDDEN"));
             PostUtil.PostResponse out = PostUtil.sendData(SUBMIT_STATS_ENDPOINT, input.toString());
             int res = out.getCode();
             PaceManTracker.logDebug("Stats Response " + res + ": " + out.getMessage());

--- a/src/main/java/gg/paceman/tracker/StateTracker.java
+++ b/src/main/java/gg/paceman/tracker/StateTracker.java
@@ -46,6 +46,8 @@ public class StateTracker {
     private long wallTime = 0;
     private long pauseStart = 0;
     private long pauseTime = 0;
+    private long netherStart = 0;
+    private long netherTime = 0;
 
     public void start() {
         this.executor.scheduleAtFixedRate(this::tickInstPath, 0, 1, TimeUnit.SECONDS);
@@ -62,6 +64,8 @@ public class StateTracker {
         this.wallTime = 0;
         this.pauseStart = 0;
         this.pauseTime = 0;
+        this.netherStart = 0;
+        this.netherTime = 0;
     }
 
     public void tickInstPath() {
@@ -182,6 +186,9 @@ public class StateTracker {
                 this.pauseTime = 0;
             }
             this.isPracticing = false;
+            if(this.isNether){
+                this.netherTime += newLM - this.netherStart;
+            }
             this.isNether = false;
         }
 
@@ -255,6 +262,7 @@ public class StateTracker {
         input.addProperty("accessKey", data.get("accessKey").getAsString());
         input.addProperty("wallTime", this.wallTime);
         input.addProperty("playTime", this.playTime);
+        input.addProperty("netherTime", this.netherTime);
         input.addProperty("seedsPlayed", this.seedsPlayed);
         input.addProperty("resets", newResets);
         input.addProperty("totalResets", this.resets);
@@ -264,6 +272,7 @@ public class StateTracker {
         this.wallTime = 0;
         this.seedsPlayed = 0;
         this.isNether = true;
+        this.netherStart = System.currentTimeMillis();
 
         try {
             PostUtil.PostResponse out = PostUtil.sendData(SUBMIT_STATS_ENDPOINT, input.toString());

--- a/src/main/java/gg/paceman/tracker/StateTracker.java
+++ b/src/main/java/gg/paceman/tracker/StateTracker.java
@@ -122,7 +122,7 @@ public class StateTracker {
             return;
         }
         long diff = newLM - this.stateLastMod;
-        if(diff > this.maxAFKTime){
+        if(this.stateLastMod != -1 && diff > this.maxAFKTime){
             PaceManTracker.logDebug("AFK for " + diff + "ms, resetting stats");
             this.reset();
         }


### PR DESCRIPTION
Internal stat counters are now reset on:
- Instance change
- Changing from a practice map to a normal run
- Enabling "Reset stats" or "Enabled" checkboxes
- 1 hour of no state changes (assumed afk/new session)

Time spent paused in the overworld is now excluded from the playTime sent to paceman for NPH

Time spent in the nether is recorded and sent to paceman (on the next enter), not for NPH but just for potential future playtime stats

Also added some debug logging for reset stat submissions and changed state tick timer from 50ms to 25ms in case seedqueue gets too fast in the future